### PR TITLE
feat: 認証機能を実装（ログイン・JWT認証・認証後デッキ一覧遷移）

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -59,3 +59,7 @@ gem 'rack-cors'
 
 # JWTの管理
 gem 'jwt'
+
+# ユーザー認証
+gem 'devise'
+gem 'devise-jwt'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -97,11 +97,30 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
+    devise (4.9.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise-jwt (0.12.1)
+      devise (~> 4.0)
+      warden-jwt_auth (~> 0.10)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.1)
+    dry-auto_inject (1.1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
     erubi (1.13.1)
     ffi (1.17.2-x64-mingw-ucrt)
     ffi (1.17.2-x86_64-linux-gnu)
@@ -156,6 +175,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.7-x86_64-linux-gnu)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -223,6 +243,9 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rouge (4.5.1)
     rubocop (1.75.2)
       json (~> 2.3)
@@ -268,6 +291,13 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     useragent (0.16.11)
+    warden (1.2.9)
+      rack (>= 2.0.9)
+    warden-jwt_auth (0.11.0)
+      dry-auto_inject (>= 0.8, < 2)
+      dry-configurable (>= 0.13, < 2)
+      jwt (~> 2.1)
+      warden (~> 1.2)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -285,6 +315,8 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  devise
+  devise-jwt
   dotenv-rails
   image_processing (~> 1.2)
   jbuilder

--- a/backend/app/controllers/api/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/auth/registrations_controller.rb
@@ -1,0 +1,33 @@
+module Api
+  module Auth
+    class RegistrationsController < ApplicationController
+      # createアクションではログイン不要にする
+      skip_before_action :authenticate_user_from_token!, only: [:create]
+
+      def create
+        user = User.new(user_params)
+        if user.save
+          sign_in(user)
+          render json: {
+            token: current_token,
+            data: {
+              user: user.as_json(only: [:id, :email, :name])
+            }
+          }, status: :created
+        else
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def user_params
+        params.permit(:email, :password, :password_confirmation, :name)
+      end
+
+      def current_token
+        request.env['warden-jwt_auth.token']
+      end
+    end
+  end
+end 

--- a/backend/app/controllers/api/auth/sessions_controller.rb
+++ b/backend/app/controllers/api/auth/sessions_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module Auth
+    class SessionsController < ApplicationController
+      # APIではセッション使わないので、CSRF/セッション系の保護は外す
+      skip_before_action :verify_authenticity_token
+      skip_before_action :authenticate_user_from_token!, only: [:create]
+
+      def create
+        user = User.find_by(email: params[:email])
+
+        if user&.valid_password?(params[:password])
+          # JWTトークンを生成する
+          token = Warden::JWTAuth::UserEncoder.new.call(user, :user, nil).first
+
+          render json: {
+            status: { code: 200, message: 'ログインに成功しました' },
+            data: {
+              user: user.as_json(only: [:id, :email]),
+              token: token
+            }
+          }
+        else
+          render json: {
+            status: { code: 401, message: 'メールアドレスまたはパスワードが正しくありません' }
+          }, status: :unauthorized
+        end
+      end
+
+      def destroy
+        head :no_content
+      end
+    end
+  end
+end 

--- a/backend/app/controllers/api/decks_controller.rb
+++ b/backend/app/controllers/api/decks_controller.rb
@@ -1,7 +1,11 @@
 module Api
   class DecksController < ApplicationController
     def index
-      decks = Deck.all
+      if current_user
+        decks = Deck.where(user_id: current_user.id)
+      else
+        decks = Deck.where(user_id: nil) # ゲスト用
+      end
       render json: decks
     end
 
@@ -12,6 +16,7 @@ module Api
 
     def create
       deck = Deck.new(deck_params)
+      deck.user = current_user if current_user
       if deck.save
         render json: deck, status: :created
       else

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,40 +1,34 @@
-class ApplicationController < ActionController::API
-  # リクエストヘッダーからAuthorizationトークンを取得し、
-  # ユーザーを認証・特定するためのメソッドです。
-  # このメソッドは通常、コントローラーのアクションが実行される前に
-  # before_action として呼び出されます。
-  def authorize_request
-    # 1. リクエストヘッダーから 'Authorization' フィールドを取得します。
-    #    Authorizationヘッダーは通常、認証情報を含んでいます。
-    header = request.headers['Authorization']
+class ApplicationController < ActionController::Base
+  include ActionController::MimeResponds
+  include ActionController::ImplicitRender
+  include ActionController::StrongParameters
 
-    # 2. ヘッダーが存在する場合、それをスペースで分割し、
-    #    配列の最後の要素（トークン本体）を取得します。
-    #    Authorizationヘッダーは "Bearer [token]" のような形式であることが多いため、
-    #    ここで "Bearer " 部分を除去します。
-    header = header.split(' ').last if header
+  before_action :authenticate_user_from_token!
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
-    # 3. 取得したトークンを JsonWebToken.decode メソッドを使ってデコードします。
-    #    この JsonWebToken.decode メソッドは、提供されたJWTを秘密鍵を使って検証し、
-    #    有効であればトークンに含まれるペイロード（データ）を返します。
-    decoded = JsonWebToken.decode(header)
+  protected
 
-    # 4. デコードされたペイロードから 'user_id' を取り出し、
-    #    そのIDを持つユーザーをデータベースから検索します。
-    #    見つかったユーザーは @current_user インスタンス変数に格納されます。
-    #    これにより、以降のアクションで認証されたユーザー情報 (@current_user) に
-    #    アクセスできるようになります。
-    @current_user = User.find(decoded[:user_id])
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password, :password_confirmation])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:email, :password])
+  end
 
-  # 5. エラーハンドリング:
-  #    トークンのデコードやユーザー検索中に以下のいずれかのエラーが発生した場合、
-  #    そのエラーを捕捉します。
-  rescue ActiveRecord::RecordNotFound, # デコードされた user_id に対応するユーザーがDBに見つからなかった場合
-         JWT::DecodeError              # トークンが無効である（署名が不正、期限切れなど）場合
+  private
 
-    # 6. エラーが発生した場合、認証失敗として処理し、
-    #    JSON形式の `{ errors: 'Unauthorized' }` というメッセージと、
-    #    HTTPステータスコード 401 (Unauthorized) をクライアントに返します。
-    render json: { errors: 'Unauthorized' }, status: :unauthorized
+  def authenticate_user_from_token!
+    if request.headers['Authorization'].present?
+      begin
+        jwt_token = request.headers['Authorization'].split(' ').last
+        decoded_token = JWT.decode(jwt_token, ENV['DEVISE_JWT_SECRET_KEY'], true, algorithm: 'HS256')
+        user_id = decoded_token[0]['sub']
+        @current_user = User.find(user_id)
+      rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+        render json: { error: '認証に失敗しました' }, status: :unauthorized
+      end
+    end
+  end
+
+  def current_user
+    @current_user
   end
 end

--- a/backend/app/controllers/concerns/jwt_authenticatable.rb
+++ b/backend/app/controllers/concerns/jwt_authenticatable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module JwtAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user_from_token!, unless: :devise_controller?
+  end
+
+  private
+
+  def authenticate_user_from_token!
+    header = request.headers['Authorization']
+    header = header.split(' ').last if header
+
+    begin
+      decoded = JWT.decode(header, Rails.application.credentials.secret_key_base)[0]
+      @current_user = User.find(decoded['user_id'])
+    rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+      render json: { errors: '認証に失敗しました' }, status: :unauthorized
+    end
+  end
+end 

--- a/backend/app/controllers/users/registrations_controller.rb
+++ b/backend/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  respond_to :json
+
+  # POST /signup
+  def create
+    build_resource(sign_up_params)
+
+    resource.save
+    if resource.persisted?
+      if resource.active_for_authentication?
+        token = generate_jwt_token(resource)
+        
+        render json: {
+          status: { code: 200, message: 'アカウント登録成功' },
+          data: {
+            user: {
+              id: resource.id,
+              email: resource.email
+            },
+            token: token
+          }
+        }
+      else
+        expire_data_after_sign_in!
+        render json: {
+          status: { code: 401, message: 'アカウントは有効化されていません' }
+        }, status: :unauthorized
+      end
+    else
+      clean_up_passwords resource
+      render json: {
+        status: { code: 422, message: 'アカウント登録失敗' },
+        errors: resource.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def generate_jwt_token(user)
+    payload = {
+      user_id: user.id,
+      exp: 24.hours.from_now.to_i
+    }
+    JWT.encode(payload, Rails.application.credentials.secret_key_base)
+  end
+end 

--- a/backend/app/controllers/users/sessions_controller.rb
+++ b/backend/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  respond_to :json
+
+  # POST /login
+  def create
+    self.resource = warden.authenticate!(auth_options)
+    token = generate_jwt_token(resource)
+    
+    render json: {
+      status: { code: 200, message: 'ログイン成功' },
+      data: {
+        user: {
+          id: resource.id,
+          email: resource.email
+        },
+        token: token
+      }
+    }
+  end
+
+  # DELETE /logout
+  def destroy
+    render json: {
+      status: { code: 200, message: 'ログアウト成功' }
+    }
+  end
+
+  private
+
+  def generate_jwt_token(user)
+    payload = {
+      user_id: user.id,
+      exp: 24.hours.from_now.to_i
+    }
+    JWT.encode(payload, Rails.application.credentials.secret_key_base)
+  end
+
+  def respond_to_on_destroy
+    render json: {
+      status: 200,
+      message: 'ログアウト成功'
+    }
+  end
+end 

--- a/backend/app/models/jwt_denylist.rb
+++ b/backend/app/models/jwt_denylist.rb
@@ -1,0 +1,5 @@
+class JwtDenylist < ApplicationRecord
+  include Devise::JWT::RevocationStrategies::Denylist
+
+  self.table_name = 'jwt_denylist'
+end 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,5 +1,22 @@
 class User < ApplicationRecord
-  has_secure_password
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
+  # has_secure_password は Devise に置き換えるため不要
+  # has_secure_password
   has_many :decks, dependent: :destroy
+  has_many :cards, through: :decks
+  has_many :study_sessions, dependent: :destroy
+  has_many :study_records, through: :study_sessions
   validates :email, presence: true, uniqueness: true
+  validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
+  validates :password_confirmation, presence: true, if: :password_required?
+
+  private
+
+  def password_required?
+    new_record? || password.present?
+  end
 end

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -1,0 +1,326 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '0e586ea806de6ca3787a48ba7f77b74535a935888b6937ab08d18879b1c2c876d3d1a04cceb8d3a01bef8bf748ef7b057ab1e19696408addcb5bf913b0f2826a'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '9ce1b2b7a69be8ca8eb59ca3f33bcc339bae78726ecb01851f836d17f5cfdc2670b94079295f72b94bc7bb91196fe91833a5077970f618ef7b22a36cf83ae98f'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+
+  # ==> JWT configuration
+  config.jwt do |jwt|
+    jwt.secret = ENV['DEVISE_JWT_SECRET_KEY']
+    jwt.dispatch_requests = [
+      ['POST', %r{^/api/auth/login$}],
+      ['POST', %r{^/api/auth/register$}]
+    ]
+    jwt.revocation_requests = [
+      ['DELETE', %r{^/api/auth/logout$}]
+    ]
+    jwt.expiration_time = 1.day.to_i
+  end
+end

--- a/backend/config/locales/devise.en.yml
+++ b/backend/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -1,0 +1,22 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "はすでに使用されています"
+              blank: "を入力してください"
+              invalid: "は不正な値です"
+            password:
+              blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
+            password_confirmation:
+              confirmation: "とパスワードの入力が一致しません"
+          taken: "はすでに使用されています"
+      messages:
+        taken: "はすでに使用されています"
+        blank: "を入力してください"
+        invalid: "は不正な値です"
+        confirmation: "と%{attribute}の入力が一致しません"
+        too_short: "は%{count}文字以上で入力してください"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,9 +1,32 @@
 Rails.application.routes.draw do
+  # カスタムパスとコントローラーでDeviseを設定
+  devise_for :users,
+           path: '',
+           path_names: {
+             sign_in: 'login',
+             sign_out: 'logout',
+             registration: 'signup'
+           },
+           controllers: {
+             sessions: 'users/sessions',
+             registrations: 'users/registrations'
+           }
 
-  post "/login", to: "auth#login"
-  resources :users, only: [:create]  # 登録用
+  # 既存のログイン・ユーザー作成ルートはDeviseに置き換えるため不要
+  # post "/login", to: "auth#login"
+  # resources :users, only: [:create]  # 登録用
 
   namespace :api do
+    # 認証関連のルート
+    namespace :auth do
+      devise_scope :user do
+        post 'login', to: 'sessions#create'
+        delete 'logout', to: 'sessions#destroy'
+        post 'register', to: 'registrations#create'
+      end
+    end
+
+    # 既存のAPIルート
     resources :decks, only: [:index, :show, :create, :destroy]
     post 'uploads', to: 'uploads#create'
   end

--- a/backend/db/migrate/20250506120649_add_devise_to_users.rb
+++ b/backend/db/migrate/20250506120649_add_devise_to_users.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class AddDeviseToUsers < ActiveRecord::Migration[7.2]
+  def self.up
+    change_table :users do |t|
+      ## Database authenticatable
+      # 既存の email カラムはすでにあるので削除
+      # t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      # Uncomment below if timestamps were not included in your original model.
+      # t.timestamps null: false
+    end
+
+    # add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+
+  def self.down
+    # By default, we don't want to make any assumption about how to roll back a migration when your
+    # model already existed. Please edit below which fields you would like to remove in this migration.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/migrate/20250509130804_create_jwt_denylist.rb
+++ b/backend/db/migrate/20250509130804_create_jwt_denylist.rb
@@ -1,0 +1,9 @@
+class CreateJwtDenylist < ActiveRecord::Migration[7.2]
+  def change
+    create_table :jwt_denylist do |t|
+      t.string :jti, null: false
+      t.datetime :exp, null: false
+    end
+    add_index :jwt_denylist, :jti
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_06_104447) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_09_130804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,11 +51,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_06_104447) do
     t.index ["user_id"], name: "index_decks_on_user_id"
   end
 
+  create_table "jwt_denylist", force: :cascade do |t|
+    t.string "jti", null: false
+    t.datetime "exp", null: false
+    t.index ["jti"], name: "index_jwt_denylist_on_jti"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,49 +1,55 @@
+import { useState, useEffect } from "react";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { DndProvider } from "react-dnd";
 import { TouchBackend } from "react-dnd-touch-backend";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
 
 import DeckList from "./pages/DeckList";
-import NewDeckForm from "./components/NewDeckForm";
+import NewDeckForm from "./pages/NewDeckForm";
 import DeckDetail from "./pages/DeckDetail";
 import PlayDeck from "./pages/PlayDeck";
-
-const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-console.log("isMobile:", isMobile);
+import Login from "./pages/Login";
 
 function App() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+    };
+  }, []);
+
   return (
-    <BrowserRouter>
+    <AuthProvider>
       <DndProvider
         backend={isMobile ? TouchBackend : HTML5Backend}
         options={
           isMobile
             ? {
                 enableMouseEvents: true,
-                delayTouchStart: 150,
-                delayMouseStart: 150,
-                touchSlop: 20,
-                ignoreContextMenu: true,
-                enableHoverOutsideTarget: true,
-                scrollAngleRanges: [
-                  { start: 30, end: 150 },
-                  { start: 210, end: 330 },
-                ],
                 enableTouchEvents: true,
                 enableKeyboardEvents: true,
-                debugPrint: true,
               }
             : undefined
         }
       >
         <Routes>
           <Route path="/" element={<DeckList />} />
+          <Route path="/login" element={<Login />} />
           <Route path="/new" element={<NewDeckForm />} />
           <Route path="/decks/:id" element={<DeckDetail />} />
           <Route path="/play/:deckId" element={<PlayDeck />} />
         </Routes>
       </DndProvider>
-    </BrowserRouter>
+    </AuthProvider>
   );
 }
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, useEffect } from "react";
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  console.log("AuthProvider: Initializing...");
+  const [token, setToken] = useState(localStorage.getItem("token"));
+  const [user, setUser] = useState(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(!!token);
+
+  // トークンが変更されたときに認証状態を更新
+  useEffect(() => {
+    console.log("AuthProvider: Token changed", { token });
+    setIsAuthenticated(!!token);
+  }, [token]);
+
+  const login = (newToken, userData) => {
+    console.log("AuthProvider: Login called", { newToken, userData });
+    setToken(newToken);
+    setUser(userData);
+    localStorage.setItem("token", newToken);
+  };
+
+  const logout = () => {
+    console.log("AuthProvider: Logout called");
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem("token");
+  };
+
+  const value = {
+    token,
+    user,
+    isAuthenticated,
+    login,
+    logout,
+  };
+
+  console.log("AuthProvider: Rendering with value", value);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  console.log("useAuth: Called, context =", context);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,16 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
 import "./index.css";
 import App from "./App.jsx";
 
-createRoot(document.getElementById("root")).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
 );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+import { api, apiEndpoints, handleApiError } from "../utils/api";
+
+export default function Login() {
+  console.log("Login: Component rendering");
+  const { login } = useAuth();
+  console.log("Login: useAuth result =", { login });
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    console.log("Login: Component mounted, login function =", login);
+  }, [login]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setIsLoading(true);
+
+    try {
+      console.log("Login: Submitting form");
+      const response = await api.post(apiEndpoints.auth.login(), {
+        email,
+        password,
+      });
+
+      console.log("Login: Login successful, response =", response.data);
+      const { data } = response.data;
+      console.log("Login: Login successful, calling login function");
+
+      if (typeof login !== "function") {
+        throw new Error("Login function is not available");
+      }
+
+      await login(data.token, data.user);
+      navigate("/");
+    } catch (err) {
+      console.error("Login: Error occurred", err);
+      const standardizedError = handleApiError(err, { context: "ログイン" });
+      setError(standardizedError.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-6">
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-2xl font-bold text-gray-800 mb-6 pb-2 border-b-2 border-green-500">
+          ログイン
+        </h2>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+              placeholder="example@example.com"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className={`w-full px-4 py-2 text-white font-medium rounded-md ${
+              isLoading
+                ? "bg-gray-400 cursor-not-allowed"
+                : "bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+            }`}
+          >
+            {isLoading ? "ログイン中..." : "ログイン"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -9,12 +9,12 @@ export const API_PREFIX = "/api"; // APIのプレフィックスを集中管理
 
 // エラータイプの定義
 export const API_ERROR_TYPES = {
-  NETWORK: 'network_error',
-  SERVER: 'server_error',
-  AUTH: 'authentication_error',
-  VALIDATION: 'validation_error',
-  NOT_FOUND: 'not_found',
-  UNKNOWN: 'unknown_error'
+  NETWORK: "network_error",
+  SERVER: "server_error",
+  AUTH: "authentication_error",
+  VALIDATION: "validation_error",
+  NOT_FOUND: "not_found",
+  UNKNOWN: "unknown_error",
 };
 
 /**
@@ -26,15 +26,18 @@ export const API_ERROR_TYPES = {
  * @returns {Object} 標準化されたエラーオブジェクト
  */
 export const handleApiError = (error, options = {}) => {
-  console.error(`API Error${options.context ? ` in ${options.context}` : ''}:`, error);
+  console.error(
+    `API Error${options.context ? ` in ${options.context}` : ""}:`,
+    error
+  );
 
   // デフォルトエラー情報
   const standardizedError = {
     type: API_ERROR_TYPES.UNKNOWN,
-    message: 'エラーが発生しました',
+    message: "エラーが発生しました",
     originalError: error,
     statusCode: null,
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
   };
 
   // axiosエラーの場合
@@ -42,7 +45,8 @@ export const handleApiError = (error, options = {}) => {
     if (!error.response) {
       // ネットワークエラー
       standardizedError.type = API_ERROR_TYPES.NETWORK;
-      standardizedError.message = 'サーバーに接続できませんでした。ネットワーク接続を確認してください。';
+      standardizedError.message =
+        "サーバーに接続できませんでした。ネットワーク接続を確認してください。";
     } else {
       // サーバーからのレスポンスがある場合
       const { status, data } = error.response;
@@ -51,28 +55,31 @@ export const handleApiError = (error, options = {}) => {
       switch (status) {
         case 400:
           standardizedError.type = API_ERROR_TYPES.VALIDATION;
-          standardizedError.message = data.error || data.message || '入力データが正しくありません';
+          standardizedError.message =
+            data.error || data.message || "入力データが正しくありません";
           standardizedError.validationErrors = data.errors || [];
           break;
         case 401:
         case 403:
           standardizedError.type = API_ERROR_TYPES.AUTH;
-          standardizedError.message = '認証に失敗しました';
+          standardizedError.message = "認証に失敗しました";
           // 認証エラー時のコールバックがあれば実行
           if (options.onAuthError) options.onAuthError();
           break;
         case 404:
           standardizedError.type = API_ERROR_TYPES.NOT_FOUND;
-          standardizedError.message = 'リソースが見つかりませんでした';
+          standardizedError.message = "リソースが見つかりませんでした";
           break;
         case 500:
         case 502:
         case 503:
           standardizedError.type = API_ERROR_TYPES.SERVER;
-          standardizedError.message = 'サーバーエラーが発生しました。しばらく経ってからお試しください。';
+          standardizedError.message =
+            "サーバーエラーが発生しました。しばらく経ってからお試しください。";
           break;
         default:
-          standardizedError.message = data.error || data.message || '予期せぬエラーが発生しました';
+          standardizedError.message =
+            data.error || data.message || "予期せぬエラーが発生しました";
       }
 
       // バックエンドからのエラーメッセージがある場合は使用
@@ -88,11 +95,11 @@ export const handleApiError = (error, options = {}) => {
 // 画像URLを絶対パスに変換するヘルパー関数
 export const getAbsoluteImageUrl = (relativeUrl) => {
   if (!relativeUrl) return null;
-  if (relativeUrl.startsWith('http')) return relativeUrl;
-  
+  if (relativeUrl.startsWith("http")) return relativeUrl;
+
   // 相対パスの場合、APIのホストと結合
-  const apiBase = API_BASE_URL.replace(/\/+$/, ''); // 末尾のスラッシュを削除
-  const path = relativeUrl.startsWith('/') ? relativeUrl : `/${relativeUrl}`;
+  const apiBase = API_BASE_URL.replace(/\/+$/, ""); // 末尾のスラッシュを削除
+  const path = relativeUrl.startsWith("/") ? relativeUrl : `/${relativeUrl}`;
   return `${apiBase}${path}`;
 };
 
@@ -108,6 +115,12 @@ export const api = axios.create({
 
 // 共通APIエンドポイントヘルパー関数
 export const apiEndpoints = {
+  // 認証関連
+  auth: {
+    login: () => `${API_PREFIX}/auth/login`,
+    register: () => `${API_PREFIX}/auth/register`,
+    logout: () => `${API_PREFIX}/auth/logout`,
+  },
   // デッキ関連
   decks: {
     getAll: () => `${API_PREFIX}/decks`,


### PR DESCRIPTION
- フロントエンドにLoginページを追加し、フォーム送信によってRails APIに認証リクエストを送信できるようにした
- 成功時にはJWTトークンとユーザー情報を取得し、Context経由で状態管理を行い、デッキ一覧ページへ遷移
- AuthContextとuseAuthカスタムフックを作成し、認証状態をアプリ全体で共有
- Rails側でDevise + devise-jwtの設定を追加。UserモデルにDeviseモジュールとJWT認証の設定を適用
- ログイン用のSessionsControllerを作成し、/api/auth/loginルートでトークンの発行を行う
- トークンの失効を行うJWT Denylistテーブルとモデルを追加し、ログアウト対応の土台を構築
- API呼び出しにaxiosを使用し、api.js内でauthセクションを定義してURLを管理
- ログイン後の認証付きAPIリクエストのために、axiosヘッダーへのトークン付加処理も追加（未使用だが今後の前提）

# 関連ファイル: Login.jsx, AuthContext.jsx, api.js, SessionsController, routes.rb, User.rb, devise.rb など