### PR TITLE
ユーザー登録処理をリファクタし、Deviseとの統合不具合を解消

### DIFF
--- a/backend/app/controllers/api/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/auth/registrations_controller.rb
@@ -1,32 +1,42 @@
 module Api
   module Auth
     class RegistrationsController < ApplicationController
-      # createアクションではログイン不要にする
+      # 認証とCSRF保護を無効化
       skip_before_action :authenticate_user_from_token!, only: [:create]
-
+      skip_before_action :verify_authenticity_token, only: [:create]
+      
       def create
-        user = User.new(user_params)
-        if user.save
-          sign_in(user)
-          render json: {
-            token: current_token,
-            data: {
-              user: user.as_json(only: [:id, :email, :name])
-            }
-          }, status: :created
-        else
-          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        begin
+          user = User.new(user_params)
+          
+          if user.save
+            # JWTトークンを生成
+            jwt_payload = { 'sub' => user.id, 'exp' => 24.hours.from_now.to_i }
+            jwt_token = JWT.encode(jwt_payload, ENV['DEVISE_JWT_SECRET_KEY'] || Rails.application.credentials.secret_key_base, 'HS256')
+            
+            render json: {
+              data: {
+                token: jwt_token,
+                user: {
+                  id: user.id,
+                  email: user.email
+                }
+              }
+            }, status: :created
+          else
+            render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+          end
+        rescue => e
+          Rails.logger.error("Registration error: #{e.message}")
+          Rails.logger.error(e.backtrace.join("\n"))
+          render json: { errors: ["サーバーエラーが発生しました。時間をおいて再度お試しください。"] }, status: :internal_server_error
         end
       end
 
       private
 
       def user_params
-        params.permit(:email, :password, :password_confirmation, :name)
-      end
-
-      def current_token
-        request.env['warden-jwt_auth.token']
+        params.require(:user).permit(:email, :password, :password_confirmation)
       end
     end
   end


### PR DESCRIPTION
- CSRFチェックを無効化しAPIとしての動作を保証
- JWT生成時のキーを柔軟に対応（ENV or credentials）
- 不要なnameパラメータを削除し、DB整合性を確保
- sign_inメソッドを使わず、直接トークン発行で制御
- レスポンス形式を統一し、フロント側での処理を簡素化
- フロントでもレスポンスの存在チェック・ログ強化