### PR TITLE
デッキ作成フォームのUX改善とプロフィール取得APIの追加

### DIFF
--- a/backend/app/controllers/api/auth/profiles_controller.rb
+++ b/backend/app/controllers/api/auth/profiles_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module Auth
+    class ProfilesController < ApplicationController
+      before_action :authenticate_user_from_token!
+
+      def show
+        render json: {
+          data: {
+            user: {
+              id: current_user.id,
+              email: current_user.email
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
         delete 'logout', to: 'sessions#destroy'
         post 'register', to: 'registrations#create'
       end
+      get 'profile', to: 'profiles#show'
     end
 
     # 既存のAPIルート


### PR DESCRIPTION
- 各カードにuploadingフラグを追加し、アップロード中の状態を管理
- スピナー表示と送信ボタンの無効化でユーザーの誤操作を防止
- AuthContextで使用する /api/auth/profile をバックエンドに追加し、404エラーを解消
- JWT認証を通じてcurrent_user情報を返すAPI構成に統一