### PR TITLE
ドロー処理をdeckの先頭に修正し、戻したカードが即ドローされる問題を解消

### DIFF
--- a/frontend/src/pages/PlayDeck.jsx
+++ b/frontend/src/pages/PlayDeck.jsx
@@ -154,7 +154,8 @@ function reducer(state, action) {
       const deckCards = state.cards.filter((card) => card.zone === "deck");
       if (deckCards.length === 0) return state; // 山札が空なら何もしない
 
-      const cardToDraw = deckCards[deckCards.length - 1];
+      // 山札の一番上（配列の先頭）のカードを引く
+      const cardToDraw = deckCards[0];
       const newCards = state.cards.map((card) =>
         card.id === cardToDraw.id
           ? { ...card, zone: "hand", isFlipped: false }


### PR DESCRIPTION
- 以前は deckCards[deckCards.length - 1] により末尾（山札の下）からドローしていた
- 山札にカードを戻す処理は正しく末尾追加だったため、ロジックが逆転していた
- 今回、ドローを deckCards[0] に変更し、deck.shift() 相当の動作へ修正
- これにより、一般的な山札の挙動（上からドロー・下に戻す）を正しく再現