### PR TITLE
ゲストモード機能＆UI全体改善

### DIFF
--- a/frontend/public/data/guestDecks.json
+++ b/frontend/public/data/guestDecks.json
@@ -1,0 +1,826 @@
+[
+  {
+    "id": "guest-deck-1",
+    "name": "光水ヘブンズゲート",
+    "cards": [
+      {
+        "id": "guest-deck-1-1",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2S10.jpg"
+      },
+      {
+        "id": "guest-deck-1-2",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2S10.jpg"
+      },
+      {
+        "id": "guest-deck-1-3",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2S10.jpg"
+      },
+      {
+        "id": "guest-deck-1-4",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2S10.jpg"
+      },
+      {
+        "id": "guest-deck-1-5",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-1-6",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-1-7",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-1-8",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-1-9",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24rp1-012.jpg"
+      },
+      {
+        "id": "guest-deck-1-10",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24rp1-012.jpg"
+      },
+      {
+        "id": "guest-deck-1-11",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24rp1-012.jpg"
+      },
+      {
+        "id": "guest-deck-1-12",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24rp1-012.jpg"
+      },
+      {
+        "id": "guest-deck-1-13",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-006.jpg"
+      },
+      {
+        "id": "guest-deck-1-14",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-006.jpg"
+      },
+      {
+        "id": "guest-deck-1-15",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-006.jpg"
+      },
+      {
+        "id": "guest-deck-1-16",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-006.jpg"
+      },
+      {
+        "id": "guest-deck-1-17",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex2-005a.jpg"
+      },
+      {
+        "id": "guest-deck-1-18",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex2-005a.jpg"
+      },
+      {
+        "id": "guest-deck-1-19",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex2-005a.jpg"
+      },
+      {
+        "id": "guest-deck-1-20",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex2-005a.jpg"
+      },
+      {
+        "id": "guest-deck-1-21",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-007.jpg"
+      },
+      {
+        "id": "guest-deck-1-22",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-007.jpg"
+      },
+      {
+        "id": "guest-deck-1-23",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-007.jpg"
+      },
+      {
+        "id": "guest-deck-1-24",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-007.jpg"
+      },
+      {
+        "id": "guest-deck-1-25",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd7-003a.jpg"
+      },
+      {
+        "id": "guest-deck-1-26",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd7-003a.jpg"
+      },
+      {
+        "id": "guest-deck-1-27",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd7-003a.jpg"
+      },
+      {
+        "id": "guest-deck-1-28",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd7-003a.jpg"
+      },
+      {
+        "id": "guest-deck-1-29",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2DM1a.jpg"
+      },
+      {
+        "id": "guest-deck-1-30",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2DM1a.jpg"
+      },
+      {
+        "id": "guest-deck-1-31",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-001.jpg"
+      },
+      {
+        "id": "guest-deck-1-32",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-001.jpg"
+      },
+      {
+        "id": "guest-deck-1-33",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd5-016.jpg"
+      },
+      {
+        "id": "guest-deck-1-34",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd5-016.jpg"
+      },
+      {
+        "id": "guest-deck-1-35",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-003a.jpg"
+      },
+      {
+        "id": "guest-deck-1-36",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24sd2-003a.jpg"
+      },
+      {
+        "id": "guest-deck-1-37",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp2x-060.jpg"
+      },
+      {
+        "id": "guest-deck-1-38",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp1-S3a.jpg"
+      },
+      {
+        "id": "guest-deck-1-39",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2S01.jpg"
+      },
+      {
+        "id": "guest-deck-1-40",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex2-002.jpg"
+      }
+    ]
+  },
+  {
+    "id": "guest-deck-2",
+    "name": "ファイアー・バード",
+    "cards": [
+      {
+        "id": "guest-deck-2-1",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-080.jpg"
+      },
+      {
+        "id": "guest-deck-2-2",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-080.jpg"
+      },
+      {
+        "id": "guest-deck-2-3",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-080.jpg"
+      },
+      {
+        "id": "guest-deck-2-4",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-080.jpg"
+      },
+      {
+        "id": "guest-deck-2-5",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-059.jpg"
+      },
+      {
+        "id": "guest-deck-2-6",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-059.jpg"
+      },
+      {
+        "id": "guest-deck-2-7",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-059.jpg"
+      },
+      {
+        "id": "guest-deck-2-8",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-059.jpg"
+      },
+      {
+        "id": "guest-deck-2-9",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-019a.jpg"
+      },
+      {
+        "id": "guest-deck-2-10",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-019a.jpg"
+      },
+      {
+        "id": "guest-deck-2-11",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-019a.jpg"
+      },
+      {
+        "id": "guest-deck-2-12",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-019a.jpg"
+      },
+      {
+        "id": "guest-deck-2-13",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-050.jpg"
+      },
+      {
+        "id": "guest-deck-2-14",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-050.jpg"
+      },
+      {
+        "id": "guest-deck-2-15",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-050.jpg"
+      },
+      {
+        "id": "guest-deck-2-16",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-050.jpg"
+      },
+      {
+        "id": "guest-deck-2-17",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-033.jpg"
+      },
+      {
+        "id": "guest-deck-2-18",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-033.jpg"
+      },
+      {
+        "id": "guest-deck-2-19",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-033.jpg"
+      },
+      {
+        "id": "guest-deck-2-20",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-033.jpg"
+      },
+      {
+        "id": "guest-deck-2-21",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-013.jpg"
+      },
+      {
+        "id": "guest-deck-2-22",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-013.jpg"
+      },
+      {
+        "id": "guest-deck-2-23",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-013.jpg"
+      },
+      {
+        "id": "guest-deck-2-24",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-013.jpg"
+      },
+      {
+        "id": "guest-deck-2-25",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-031.jpg"
+      },
+      {
+        "id": "guest-deck-2-26",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-031.jpg"
+      },
+      {
+        "id": "guest-deck-2-27",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-031.jpg"
+      },
+      {
+        "id": "guest-deck-2-28",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-031.jpg"
+      },
+      {
+        "id": "guest-deck-2-29",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-004.jpg"
+      },
+      {
+        "id": "guest-deck-2-30",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-004.jpg"
+      },
+      {
+        "id": "guest-deck-2-31",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-004.jpg"
+      },
+      {
+        "id": "guest-deck-2-32",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-004.jpg"
+      },
+      {
+        "id": "guest-deck-2-33",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp3-011.jpg"
+      },
+      {
+        "id": "guest-deck-2-34",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp3-011.jpg"
+      },
+      {
+        "id": "guest-deck-2-35",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp3-011.jpg"
+      },
+      {
+        "id": "guest-deck-2-36",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp4x-028.jpg"
+      },
+      {
+        "id": "guest-deck-2-37",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp4x-028.jpg"
+      },
+      {
+        "id": "guest-deck-2-38",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm22ex2-062.jpg"
+      },
+      {
+        "id": "guest-deck-2-39",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23sd3-002.jpg"
+      },
+      {
+        "id": "guest-deck-2-40",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp2-S06.jpg"
+      }
+    ]
+  },
+  {
+    "id": "guest-deck-3",
+    "name": "ドリームメイト",
+    "cards": [
+      {
+        "id": "guest-deck-3-1",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-024.jpg"
+      },
+      {
+        "id": "guest-deck-3-2",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-024.jpg"
+      },
+      {
+        "id": "guest-deck-3-3",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-024.jpg"
+      },
+      {
+        "id": "guest-deck-3-4",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-024.jpg"
+      },
+      {
+        "id": "guest-deck-3-5",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp3-TF04.jpg"
+      },
+      {
+        "id": "guest-deck-3-6",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp3-TF04.jpg"
+      },
+      {
+        "id": "guest-deck-3-7",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp3-TF04.jpg"
+      },
+      {
+        "id": "guest-deck-3-8",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2S10.jpg"
+      },
+      {
+        "id": "guest-deck-3-9",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-045a.jpg"
+      },
+      {
+        "id": "guest-deck-3-10",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-045a.jpg"
+      },
+      {
+        "id": "guest-deck-3-11",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-045a.jpg"
+      },
+      {
+        "id": "guest-deck-3-12",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-045a.jpg"
+      },
+      {
+        "id": "guest-deck-3-13",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-065.jpg"
+      },
+      {
+        "id": "guest-deck-3-14",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-065.jpg"
+      },
+      {
+        "id": "guest-deck-3-15",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-065.jpg"
+      },
+      {
+        "id": "guest-deck-3-16",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-065.jpg"
+      },
+      {
+        "id": "guest-deck-3-17",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-043.jpg"
+      },
+      {
+        "id": "guest-deck-3-18",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-043.jpg"
+      },
+      {
+        "id": "guest-deck-3-19",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-043.jpg"
+      },
+      {
+        "id": "guest-deck-3-20",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-043.jpg"
+      },
+      {
+        "id": "guest-deck-3-21",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-016.jpg"
+      },
+      {
+        "id": "guest-deck-3-22",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-016.jpg"
+      },
+      {
+        "id": "guest-deck-3-23",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-016.jpg"
+      },
+      {
+        "id": "guest-deck-3-24",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-016.jpg"
+      },
+      {
+        "id": "guest-deck-3-25",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-022a.jpg"
+      },
+      {
+        "id": "guest-deck-3-26",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-022a.jpg"
+      },
+      {
+        "id": "guest-deck-3-27",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-022a.jpg"
+      },
+      {
+        "id": "guest-deck-3-28",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-022a.jpg"
+      },
+      {
+        "id": "guest-deck-3-29",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-051.jpg"
+      },
+      {
+        "id": "guest-deck-3-30",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-051.jpg"
+      },
+      {
+        "id": "guest-deck-3-31",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-051.jpg"
+      },
+      {
+        "id": "guest-deck-3-32",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-051.jpg"
+      },
+      {
+        "id": "guest-deck-3-33",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-011.jpg"
+      },
+      {
+        "id": "guest-deck-3-34",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-011.jpg"
+      },
+      {
+        "id": "guest-deck-3-35",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex1-011.jpg"
+      },
+      {
+        "id": "guest-deck-3-36",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd4-051.jpg"
+      },
+      {
+        "id": "guest-deck-3-37",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex4-PR034.jpg"
+      },
+      {
+        "id": "guest-deck-3-38",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-080.jpg"
+      },
+      {
+        "id": "guest-deck-3-39",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24rp1-T07.jpg"
+      },
+      {
+        "id": "guest-deck-3-40",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp3010.jpg"
+      }
+    ]
+  },
+  {
+    "id": "guest-deck-4",
+    "name": "ペテンシーフシギバース",
+    "cards": [
+      {
+        "id": "guest-deck-4-1",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp2x-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-2",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp2x-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-3",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp2x-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-4",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23rp2x-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-5",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmex16-073.jpg"
+      },
+      {
+        "id": "guest-deck-4-6",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmex16-073.jpg"
+      },
+      {
+        "id": "guest-deck-4-7",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmex16-073.jpg"
+      },
+      {
+        "id": "guest-deck-4-8",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmex16-073.jpg"
+      },
+      {
+        "id": "guest-deck-4-9",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-4-10",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-4-11",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-4-12",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm25rp1-S07.jpg"
+      },
+      {
+        "id": "guest-deck-4-13",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24bd5-006.jpg"
+      },
+      {
+        "id": "guest-deck-4-14",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24bd5-006.jpg"
+      },
+      {
+        "id": "guest-deck-4-15",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24bd5-006.jpg"
+      },
+      {
+        "id": "guest-deck-4-16",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24bd5-006.jpg"
+      },
+      {
+        "id": "guest-deck-4-17",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-18",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-19",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-20",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-015.jpg"
+      },
+      {
+        "id": "guest-deck-4-21",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-003.jpg"
+      },
+      {
+        "id": "guest-deck-4-22",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-003.jpg"
+      },
+      {
+        "id": "guest-deck-4-23",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-003.jpg"
+      },
+      {
+        "id": "guest-deck-4-24",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23ex1-003.jpg"
+      },
+      {
+        "id": "guest-deck-4-25",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-017.jpg"
+      },
+      {
+        "id": "guest-deck-4-26",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-017.jpg"
+      },
+      {
+        "id": "guest-deck-4-27",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-017.jpg"
+      },
+      {
+        "id": "guest-deck-4-28",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-017.jpg"
+      },
+      {
+        "id": "guest-deck-4-29",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp4002.jpg"
+      },
+      {
+        "id": "guest-deck-4-30",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp4002.jpg"
+      },
+      {
+        "id": "guest-deck-4-31",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp3010.jpg"
+      },
+      {
+        "id": "guest-deck-4-32",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp3010.jpg"
+      },
+      {
+        "id": "guest-deck-4-33",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2DM1a.jpg"
+      },
+      {
+        "id": "guest-deck-4-34",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm24ex3-rp2DM1a.jpg"
+      },
+      {
+        "id": "guest-deck-4-35",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmrp14-s05.jpg"
+      },
+      {
+        "id": "guest-deck-4-36",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmrp14-s05.jpg"
+      },
+      {
+        "id": "guest-deck-4-37",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmex19-m9.jpg"
+      },
+      {
+        "id": "guest-deck-4-38",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmex19-m9.jpg"
+      },
+      {
+        "id": "guest-deck-4-39",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dmrp10-014a.jpg"
+      },
+      {
+        "id": "guest-deck-4-40",
+        "name": "",
+        "imageUrl": "https://dm.takaratomy.co.jp/wp-content/card/cardimage/dm23bd7-003a.jpg"
+      }
+    ]
+  }
+]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -58,6 +58,8 @@ function App() {
               <Route path="/register" element={<Register />} />
               <Route path="/new" element={<NewDeckForm />} />
               <Route path="/decks/:id" element={<DeckDetail />} />
+              <Route path="/decks/guest/:id" element={<DeckDetail />} />
+              <Route path="/play/guest/:deckId" element={<PlayDeck />} />
               <Route path="/play/:deckId" element={<PlayDeck />} />
             </Routes>
           </main>

--- a/frontend/src/components/HandArea.jsx
+++ b/frontend/src/components/HandArea.jsx
@@ -9,8 +9,15 @@ import Card from "./Card";
  * @param {function} props.onClickCard カードをクリックしたときの処理
  * @param {function} props.onDropFromField フィールドからのカードを受け取ったときの処理
  * @param {string} props.activeMode 現在のアクティブなモード
+ * @param {boolean} props.isShuffling シャッフル中かどうか
  */
-const HandArea = ({ handCards, onClickCard, onDropFromField, activeMode }) => {
+const HandArea = ({
+  handCards,
+  onClickCard,
+  onDropFromField,
+  activeMode,
+  isShuffling,
+}) => {
   const [{ isOver }, dropRef] = useDrop({
     accept: "CARD",
     drop: (item) => {
@@ -25,6 +32,7 @@ const HandArea = ({ handCards, onClickCard, onDropFromField, activeMode }) => {
 
   // モードメッセージの取得
   const getModeMessage = () => {
+    if (isShuffling) return "シャッフル中...";
     if (!activeMode) return null;
 
     const messages = {
@@ -62,18 +70,36 @@ const HandArea = ({ handCards, onClickCard, onDropFromField, activeMode }) => {
         </div>
       )}
 
-      {/* モード中のメッセージ表示 - 手札エリア内下部 */}
-      {activeMode && (
-        <div className="sticky left-0 right-0 bottom-0 min-w-full text-sm text-blue-700 font-semibold text-center bg-blue-100 bg-opacity-90 py-1 border-t border-blue-200 whitespace-normal">
-          {getModeMessage()}
+      {/* 常に表示される操作ガイド */}
+      <div
+        className={`sticky left-0 right-0 bottom-0 min-w-full text-xs ${
+          isShuffling
+            ? "text-purple-700 bg-purple-100"
+            : "text-blue-700 bg-blue-100"
+        } font-semibold text-center bg-opacity-90 py-1 border-t ${
+          isShuffling ? "border-purple-200" : "border-blue-200"
+        } whitespace-normal flex justify-center items-center transition-colors duration-300`}
+      >
+        <div className="text-center">
+          {activeMode || isShuffling ? (
+            getModeMessage()
+          ) : (
+            <>
+              自由にカードをドラッグ＆ドロップ。
+              <span className="md:inline hidden">&nbsp;</span>
+              <br className="md:hidden" />
+              カードをタップして90度回転できます。
+            </>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };
 
 HandArea.defaultProps = {
   activeMode: null,
+  isShuffling: false,
 };
 
 export default HandArea;

--- a/frontend/src/pages/DeckList.jsx
+++ b/frontend/src/pages/DeckList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from "react";
+import React, { useEffect, useReducer, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { api, apiEndpoints, handleApiError } from "../utils/api";
 import { useAuth } from "../contexts/AuthContext";
@@ -33,6 +33,9 @@ function reducer(state, action) {
 
 const DeckList = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const [guestDecks, setGuestDecks] = useState([]);
+  const [loadingGuestDecks, setLoadingGuestDecks] = useState(false);
+  const [guestDecksError, setGuestDecksError] = useState(null);
   const { isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
@@ -50,8 +53,28 @@ const DeckList = () => {
     }
   };
 
+  // ゲストデッキの取得
+  const fetchGuestDecks = async () => {
+    setLoadingGuestDecks(true);
+    setGuestDecksError(null);
+    try {
+      const response = await fetch("/data/guestDecks.json");
+      if (!response.ok) {
+        throw new Error("ゲストデッキの取得に失敗しました");
+      }
+      const data = await response.json();
+      setGuestDecks(data);
+    } catch (error) {
+      console.error("Error fetching guest decks:", error);
+      setGuestDecksError(error.message || "ゲストデッキの取得に失敗しました");
+    } finally {
+      setLoadingGuestDecks(false);
+    }
+  };
+
   useEffect(() => {
     fetchDecks();
+    fetchGuestDecks();
   }, []);
 
   // デッキの削除
@@ -82,6 +105,106 @@ const DeckList = () => {
     // デフォルト画像
     return "/images/default-card.jpg";
   };
+
+  // 共通のデッキカードコンポーネント
+  const DeckCard = ({ deck, isGuest = false }) => (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 flex flex-col">
+      <div className="relative h-48 bg-gray-200">
+        <img
+          src={getThumbnailUrl(deck)}
+          alt={deck.name}
+          className="w-full h-full object-cover"
+          onError={(e) => {
+            e.target.src = "/images/default-card.jpg";
+          }}
+        />
+        {isGuest && (
+          <div className="absolute top-0 right-0 bg-yellow-500 text-white px-2 py-1 text-xs font-bold">
+            ゲスト
+          </div>
+        )}
+      </div>
+      <div className="p-5 flex flex-col flex-grow">
+        <h3 className="text-lg font-semibold text-gray-800 mb-2 truncate">
+          {deck.name}
+        </h3>
+        <div className="mt-auto grid grid-cols-2 gap-2">
+          <Link
+            to={
+              isGuest
+                ? `/decks/guest/${deck.id.replace("guest-", "")}`
+                : `/decks/${deck.id}`
+            }
+            className="px-3 py-2 bg-blue-500 text-white text-center rounded-md hover:bg-blue-600 transition-colors text-sm font-medium flex items-center justify-center"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4 mr-1"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              />
+            </svg>
+            詳細
+          </Link>
+          <Link
+            to={isGuest ? `/play/guest/${deck.id}` : `/play/${deck.id}`}
+            className="px-3 py-2 bg-green-500 text-white text-center rounded-md hover:bg-green-600 transition-colors text-sm font-medium flex items-center justify-center"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4 mr-1"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
+                clipRule="evenodd"
+              />
+            </svg>
+            プレイ
+          </Link>
+          {!isGuest && (
+            <button
+              onClick={(e) => handleDelete(e, deck.id)}
+              className="col-span-2 mt-2 px-3 py-2 bg-red-100 text-red-600 rounded-md hover:bg-red-200 transition-colors flex items-center justify-center"
+              disabled={state.isLoading}
+              aria-label="削除"
+            >
+              <svg
+                className="w-4 h-4 mr-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                />
+              </svg>
+              削除
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div className="max-w-6xl px-4 py-8 mx-auto">
@@ -142,84 +265,89 @@ const DeckList = () => {
           </div>
         )}
 
-        {/* ローディング表示 */}
-        {state.isLoading && (
-          <div className="flex justify-center items-center my-6">
-            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
-            <span className="ml-2 text-gray-600">読み込み中...</span>
-          </div>
-        )}
+        {/* ユーザーデッキセクション - ログイン済みの場合のみ表示 */}
+        {isAuthenticated && (
+          <section>
+            <h2 className="text-xl font-bold mb-4 text-gray-800 pb-2 border-b border-gray-200">
+              あなたのデッキ
+            </h2>
 
-        {/* デッキがない場合の表示 */}
-        {!state.isLoading && state.decks.length === 0 && !state.error && (
-          <div className="flex flex-col items-center justify-center p-12 bg-gray-50 rounded-lg">
-            <p className="mb-2 text-xl font-medium text-gray-700">
-              デッキがありません
-            </p>
-            <p className="text-gray-500">最初のデッキを作成しましょう！</p>
-          </div>
-        )}
+            {/* ローディング表示 */}
+            {state.isLoading && (
+              <div className="flex justify-center items-center my-6">
+                <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
+                <span className="ml-2 text-gray-600">読み込み中...</span>
+              </div>
+            )}
 
-        {/* デッキ一覧（カードグリッド） */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-          {state.decks.map((deck) => (
-            <div
-              key={deck.id}
-              className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 flex flex-col"
-            >
-              <div className="relative h-48 bg-gray-200">
-                <img
-                  src={getThumbnailUrl(deck)}
-                  alt={deck.name}
-                  className="w-full h-full object-cover"
-                  onError={(e) => {
-                    e.target.src = "/images/default-card.jpg";
-                  }}
-                />
-              </div>
-              <div className="p-5 flex flex-col flex-grow">
-                <h3 className="text-lg font-semibold text-gray-800 mb-4 truncate">
-                  {deck.name}
-                </h3>
-                <div className="mt-auto flex justify-between space-x-3 pt-3">
+            {/* デッキがない場合の表示 */}
+            {!state.isLoading && state.decks.length === 0 && !state.error && (
+              <div className="flex flex-col items-center justify-center p-8 bg-gray-50 rounded-lg">
+                <p className="mb-2 text-lg font-medium text-gray-700">
+                  デッキがありません
+                </p>
+                <p className="text-gray-500 mb-4">
+                  最初のデッキを作成しましょう！
+                </p>
+                {isAuthenticated && (
                   <Link
-                    to={`/decks/${deck.id}`}
-                    className="flex-1 px-3 py-2 bg-blue-500 text-white text-center rounded-md hover:bg-blue-600 transition-colors text-sm font-medium"
+                    to="/new"
+                    className="inline-flex items-center px-4 py-2 bg-blue-500 text-white font-medium rounded hover:bg-blue-600 shadow-sm"
                   >
-                    詳細
+                    新規デッキを作成
                   </Link>
-                  <Link
-                    to={`/play/${deck.id}`}
-                    className="flex-1 px-3 py-2 bg-green-500 text-white text-center rounded-md hover:bg-green-600 transition-colors text-sm font-medium"
-                  >
-                    プレイ
-                  </Link>
-                  <button
-                    onClick={(e) => handleDelete(e, deck.id)}
-                    className="px-3 py-2 bg-red-100 text-red-600 rounded-md hover:bg-red-200 transition-colors"
-                    disabled={state.isLoading}
-                    aria-label="削除"
-                  >
-                    <svg
-                      className="w-5 h-5"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                )}
               </div>
+            )}
+
+            {/* ユーザーデッキ一覧 */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-8">
+              {state.decks.map((deck) => (
+                <DeckCard key={deck.id} deck={deck} isGuest={false} />
+              ))}
             </div>
-          ))}
-        </div>
+          </section>
+        )}
+
+        {/* ゲストデッキセクション */}
+        <section className={isAuthenticated ? "mt-10" : ""}>
+          <h2 className="text-xl font-bold mb-4 text-gray-800 pb-2 border-b border-gray-200">
+            ゲスト用デッキ
+          </h2>
+
+          {/* ゲストデッキのローディング表示 */}
+          {loadingGuestDecks && (
+            <div className="flex justify-center items-center my-6">
+              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-yellow-500"></div>
+              <span className="ml-2 text-gray-600">
+                ゲストデッキを読み込み中...
+              </span>
+            </div>
+          )}
+
+          {/* ゲストデッキのエラー表示 */}
+          {guestDecksError && (
+            <div className="mb-6 p-4 bg-yellow-100 border border-yellow-300 rounded-md text-yellow-700">
+              <p className="font-medium">
+                ゲストデッキの読み込みに失敗しました
+              </p>
+              <p>{guestDecksError}</p>
+              <button
+                onClick={fetchGuestDecks}
+                className="mt-2 px-3 py-1 bg-yellow-100 border border-yellow-500 rounded-md hover:bg-yellow-200 text-sm"
+              >
+                再試行
+              </button>
+            </div>
+          )}
+
+          {/* ゲストデッキ一覧 */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {guestDecks.map((deck) => (
+              <DeckCard key={deck.id} deck={deck} isGuest={true} />
+            ))}
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -71,7 +71,7 @@ const Home = () => {
                   ログインして始める
                 </button>
                 <button
-                  onClick={() => navigate("/play/guest")}
+                  onClick={() => navigate("/decks")}
                   className="bg-yellow-400 hover:bg-yellow-500 text-gray-800 font-bold py-4 px-8 rounded-lg shadow-md transition-colors text-lg flex items-center justify-center"
                 >
                   <svg
@@ -168,7 +168,7 @@ const Home = () => {
                 </Link>
               ) : (
                 <Link
-                  to="/play/guest"
+                  to="/decks"
                   className="inline-flex items-center text-blue-700 hover:text-blue-800 font-medium"
                 >
                   ログインせずに遊ぶ


### PR DESCRIPTION
【機能追加】
- ゲスト用デフォルトデッキをguestDecks.jsonから読み込み
- DeckListにゲストデッキを統合表示、編集不可でプレイのみ可
- ゲストデッキのルーティングをAppに追加（/decks/guest/, /play/guest/）
- プレイ画面でゲスト用デッキを正しく読み込み、重複（120枚）問題を修正

【UI/UX改善】
- DeckList：カード数表示、グリッドボタン配置、削除ボタン明示
- DeckDetail：プレイボタンとデッキ名の並列化、レスポンシブ対応
- PlayDeck：操作ガイド常時表示、シャッフルボタンにアニメ、裏返しモード表示統一
- ホーム：未ログイン時のUI調整、「ログインせずに試す」ボタンの遷移修正

【コード品質】
- ゲストデッキ検出ロジックの統一
- 画像URLエラーのフォールバック強化
- API呼び出し・ルート遷移の一貫性改善
- スタイル・構造の統一による保守性向上