### PR TITLE
feat: カードIDと詳細URLからの画像自動取得・アップロード機能を実装

### DIFF
--- a/backend/app/controllers/api/proxy_controller.rb
+++ b/backend/app/controllers/api/proxy_controller.rb
@@ -1,0 +1,23 @@
+require 'net/http'
+
+class Api::ProxyController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user_from_token!
+
+  def image
+    url = params[:url]
+
+    begin
+      uri = URI.parse(url)
+      response = Net::HTTP.get_response(uri)
+
+      if response.is_a?(Net::HTTPSuccess)
+        send_data response.body, type: response.content_type, disposition: "inline"
+      else
+        render json: { error: "画像取得に失敗しました" }, status: :bad_gateway
+      end
+    rescue => e
+      render json: { error: "例外: #{e.message}" }, status: :internal_server_error
+    end
+  end
+end 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
     resources :cards, only: [] do
       get 'image', to: 'cards#image', on: :member
     end
+
+    # 画像プロキシAPI（CORS対策用）
+    get "proxy", to: "proxy#image"
   end
   
   # ActiveStorageのルーティング


### PR DESCRIPTION
- dmXXrpX-XXX形式のカードIDを直接ドロップ可能に
- takaratomy公式カード詳細ページURLからIDを抽出し画像URLを自動生成
- ActiveStorageへのアップロード前にCORS回避用のRailsプロキシ経由で画像を取得
- 新しい画像追加方式（計5種）に対応：
  - 一般画像ファイル
  - Web上の画像
  - 既存カード
  - カードID
  - カード詳細URL
- 取得手順を段階的にフォールバックすることで安定性を向上