### PR TITLE
認証リクエストの処理方式改善: Accept: application/json ヘッダー追加

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -56,6 +56,7 @@ export const AuthProvider = ({ children }) => {
         const response = await api.get(`${apiEndpoints.auth.profile()}`, {
           headers: {
             Authorization: `Bearer ${token}`,
+            Accept: "application/json",
           },
           withCredentials: false,
         });

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -38,6 +38,7 @@ export default function Login() {
         {
           headers: {
             "Content-Type": "application/json",
+            Accept: "application/json",
           },
           withCredentials: false,
           timeout: 60000,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -121,6 +121,7 @@ export const api = axios.create({
   baseURL: API_BASE_URL, // 絶対パスを使用
   headers: {
     "Content-Type": "application/json",
+    Accept: "application/json",
   },
   // 大きなファイルをアップロードできるように設定を追加
   maxContentLength: 100 * 1024 * 1024, // 100MB
@@ -191,6 +192,9 @@ api.interceptors.request.use((config) => {
   if (!config.headers["Content-Type"]) {
     config.headers["Content-Type"] = "application/json";
   }
+
+  // 常にJSONレスポンスを要求
+  config.headers["Accept"] = "application/json";
 
   console.log(`API Interceptor: Final headers:`, config.headers);
   return config;


### PR DESCRIPTION
Login.jsxのリクエストに Accept: application/json ヘッダーを追加
api.jsのデフォルトヘッダーとインターセプターに Accept: application/json を設定 AuthContext.jsxのプロファイル取得リクエストにAcceptヘッダーを追加