### PR TITLE
application_controller.rb の authenticate_user_from_token! メソッドを修正：

### DIFF
--- a/backend/app/controllers/concerns/jwt_authenticatable.rb
+++ b/backend/app/controllers/concerns/jwt_authenticatable.rb
@@ -14,9 +14,27 @@ module JwtAuthenticatable
     header = header.split(' ').last if header
 
     begin
+      # デバッグログ
+      Rails.logger.info("JWT Token (from concern): #{header}")
+      
+      # トークンをデコード
       decoded = JWT.decode(header, Rails.application.credentials.secret_key_base)[0]
-      @current_user = User.find(decoded['user_id'])
-    rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+      Rails.logger.info("Decoded token (from concern): #{decoded.inspect}")
+      
+      # 両方の形式をサポート
+      user_id = decoded['sub'] || decoded['user_id']
+      Rails.logger.info("Extracted user_id (from concern): #{user_id}")
+      
+      @current_user = User.find(user_id)
+      Rails.logger.info("Found user (from concern): #{@current_user.id}")
+    rescue JWT::DecodeError => e
+      Rails.logger.error("JWT decode error (from concern): #{e.message}")
+      render json: { errors: '認証に失敗しました' }, status: :unauthorized
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error("User not found (from concern): #{e.message}")
+      render json: { errors: '認証に失敗しました' }, status: :unauthorized
+    rescue => e
+      Rails.logger.error("Unexpected error (from concern): #{e.message}")
       render json: { errors: '認証に失敗しました' }, status: :unauthorized
     end
   end


### PR DESCRIPTION
両方のキー形式（'sub'と'user_id'）をサポート
詳細なデバッグログを追加
秘密鍵の設定をフォールバック付きで統一
jwt_authenticatable.rb コンサーンも同様に修正：
両方のキー形式（'sub'と'user_id'）をサポート
デバッグログの追加
よりきめ細かい例外処理